### PR TITLE
Bump django-constance to v0.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,7 +90,7 @@
 	url = git://github.com/praekelt/django-recaptcha.git
 [submodule "src/django-constance"]
 	path = src/django-constance
-	url = git://github.com/jezdez/django-constance.git
+	url = git://github.com/comoga/django-constance.git
 [submodule "src/requests"]
 	path = src/requests
 	url = git://github.com/kennethreitz/requests.git


### PR DESCRIPTION
Looks like the version we have didn't include migrations, and needed an upgrade from the official repo.
